### PR TITLE
Bump default value for "-limiter" parameter.

### DIFF
--- a/src/sdhlt/sdHLRAD/qrad.h
+++ b/src/sdhlt/sdHLRAD/qrad.h
@@ -52,9 +52,9 @@
 #define DEFAULT_AMBIENT_RED         0.0
 #define DEFAULT_AMBIENT_GREEN       0.0
 #define DEFAULT_AMBIENT_BLUE        0.0
-// 188 is the fullbright threshold for Goldsrc, regardless of the brightness and gamma settings in the graphic options.
+// 188 is the fullbright threshold for pre-Anniversary update Goldsrc, regardless of the brightness and gamma settings in the graphic options.
 // However, hlrad can only control the light values of each single light style. So the final in-game brightness may exceed 188 if you have set a high value in the "custom appearance" of the light, or if the face receives light from different styles.
-#define DEFAULT_LIMITTHRESHOLD		188.0
+#define DEFAULT_LIMITTHRESHOLD		255.0
 #define DEFAULT_TEXSCALE            true
 #define DEFAULT_CHOP                64.0
 #define DEFAULT_TEXCHOP             32.0


### PR DESCRIPTION
This feature was added as a hack/workaround in ZHLT/VHLT version 31 for overbright not working in GoldSrc, However after the 25th Anniversary update for GoldSrc/Half-Life this is no longer needed to be at such a low value.

`255` may not be the perfect value (might be better to just disable the lightmap limiter altogether?), However it is a way better value then `188` and is what ZHLT/VHLT recommended for the Trinity Renderer which doesn't suffer from overbright not working so I would say this is fine for now.

Also might be worth it to update the readme since there is likely a large amount of people who are unaware of this.