### PR TITLE
Add info_room and info_room_target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,5 @@ Temporary Items
 !/tools/wad.cfg
 
 *.zip
+
+/build*/

--- a/src/sdhlt/sdHLVIS/vis.cpp
+++ b/src/sdhlt/sdHLVIS/vis.cpp
@@ -1834,10 +1834,7 @@ int             main(const int argc, char** argv)
 				}
 			}
 
-            // Check for length because we have `info_room` and `info_room_target`
-            else if (!strcmp (current_entity_classname, "info_room")
-                && strlen(current_entity_classname) == strlen("info_room")
-                )
+            else if (!strcmp (current_entity_classname, "info_room"))
             {
                 if (g_room_count < g_room_max)
                 {

--- a/src/sdhlt/sdHLVIS/vis.cpp
+++ b/src/sdhlt/sdHLVIS/vis.cpp
@@ -16,10 +16,13 @@
 #ifdef SYSTEM_WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+// std:clamp() is at least MVSC 19
+#define CLAMP(x, min, max) x <= min ? min : x >= max ? max : x
 #endif
 
 #ifdef SYSTEM_POSIX
 #include <algorithm>
+#define CLAMP(x, min, max) std::clamp(x, min, max)
 #endif
 
 #ifdef ZHLT_NETVIS
@@ -1877,7 +1880,7 @@ int             main(const int argc, char** argv)
 
                     GetVectorForKey (&g_entities[i], "origin", room_origin);
                     g_room[g_room_count].visleafnum = VisLeafnumForPoint (room_origin);
-                    g_room[g_room_count].neighbor = std::clamp(IntForKey (&g_entities[i], "neighbor"), 0, MAX_ROOM_NEIGHBOR);
+                    g_room[g_room_count].neighbor = CLAMP(IntForKey (&g_entities[i], "neighbor"), 0, MAX_ROOM_NEIGHBOR);
 
                     const char* target = ValueForKey (&g_entities[i], "target");
 

--- a/src/sdhlt/sdHLVIS/vis.cpp
+++ b/src/sdhlt/sdHLVIS/vis.cpp
@@ -1872,7 +1872,7 @@ int             main(const int argc, char** argv)
 				}
 			}
 
-            else if (!strcmp (current_entity_classname, "info_room"))
+            else if (!strcmp (current_entity_classname, "info_portal"))
             {
                 if (g_room_count < g_room_max)
                 {
@@ -1897,8 +1897,8 @@ int             main(const int argc, char** argv)
                     {
                         const char* current_entity_classname_nested = ValueForKey (&g_entities[j], "classname");
 
-                        // Find a `info_room_target` and check if its targetname matches our target
-                        if (!strcmp (current_entity_classname_nested, "info_room_target")
+                        // Find a `info_leaf` and check if its targetname matches our target
+                        if (!strcmp (current_entity_classname_nested, "info_leaf")
                             && !strcmp(ValueForKey (&g_entities[j], "targetname"), target))
                         {
                             vec3_t room_target_origin;
@@ -1912,7 +1912,7 @@ int             main(const int argc, char** argv)
 
                     if (!has_target)
                     {
-                        Warning("Entity %d (info_room) does not have a target.", i);
+                        Warning("Entity %d (info_portal) does not have a target leaf.", i);
                     }
 
                     g_room_count++;

--- a/src/sdhlt/sdHLVIS/vis.h
+++ b/src/sdhlt/sdHLVIS/vis.h
@@ -18,6 +18,8 @@
 #include "zones.h"
 #include "cmdlinecfg.h"
 
+#include <vector>
+
 #define DEFAULT_MAXDISTANCE_RANGE   0
 
 
@@ -143,6 +145,21 @@ extern unsigned g_portalleafs;
 
 extern unsigned int g_maxdistance;
 //extern bool		g_postcompile;
+
+// This allows the current leaf to have portal to selected leaf.
+// TODO: vector for target so it can do a lot. Though doing the entity won't be as simple.
+// That means we need to parse string and what not. 
+// For the time being, ONE target is good enough.
+typedef struct
+{
+    int visleafnum;
+    int target_visleafnum;
+}
+room_t;
+extern const int g_room_max;
+extern room_t g_room[];
+extern int g_room_count;
+
 typedef struct
 {
 	vec3_t origin;
@@ -158,6 +175,8 @@ typedef struct
 {
 	bool isoverviewpoint;
 	bool isskyboxpoint;
+    // For info_room
+    std::vector<int> additional_leaves;
 }
 leafinfo_t;
 extern leafinfo_t *g_leafinfos;

--- a/src/sdhlt/sdHLVIS/vis.h
+++ b/src/sdhlt/sdHLVIS/vis.h
@@ -19,6 +19,7 @@
 #include "cmdlinecfg.h"
 
 #include <vector>
+#include <unordered_map>
 
 #define DEFAULT_MAXDISTANCE_RANGE   0
 
@@ -150,15 +151,19 @@ extern unsigned int g_maxdistance;
 // TODO: vector for target so it can do a lot. Though doing the entity won't be as simple.
 // That means we need to parse string and what not. 
 // For the time being, ONE target is good enough.
+#define MAX_ROOM_NEIGHBOR 16
 typedef struct
 {
     int visleafnum;
     int target_visleafnum;
+    // Traversal of neighbors being affected.
+    int neighbor;
 }
 room_t;
 extern const int g_room_max;
 extern room_t g_room[];
 extern int g_room_count;
+extern std::unordered_map<int, bool> leaf_flow_add_exclude;
 
 typedef struct
 {
@@ -177,6 +182,7 @@ typedef struct
 	bool isskyboxpoint;
     // For info_room
     std::vector<int> additional_leaves;
+    int neighbor;
 }
 leafinfo_t;
 extern leafinfo_t *g_leafinfos;

--- a/src/sdhlt/sdHLVIS/vis.h
+++ b/src/sdhlt/sdHLVIS/vis.h
@@ -180,7 +180,7 @@ typedef struct
 {
 	bool isoverviewpoint;
 	bool isskyboxpoint;
-    // For info_room
+    // For info_portal
     std::vector<int> additional_leaves;
     int neighbor;
 }

--- a/tools/sdhlt.fgd
+++ b/tools/sdhlt.fgd
@@ -86,6 +86,19 @@
 	]
 ]
 
+// info_room
+// It makes all entities inside info_room_target visible inside the room where this entity is.
+@PointClass color(255 255 255) = info_room : "Disable VIS in info_room_target for this room"
+[
+	target(target_source) : "Name of info_room_target"
+]
+
+// info_room_target
+@PointClass color(255 255 255) = info_room_target : "Disable VIS in this room for info_room"
+[
+	targetname(target_destination) : "Name"
+]
+
 // info_sunlight
 // It generates a fake light_environment which defines sv_skycolor and sv_skyvec in game.
 // If you are using multiple light_environments, you will probably need this entity.

--- a/tools/sdhlt.fgd
+++ b/tools/sdhlt.fgd
@@ -91,6 +91,7 @@
 @PointClass color(255 255 255) = info_room : "Disable VIS in info_room_target for this room"
 [
 	target(target_source) : "Name of info_room_target"
+	neighbor(interger) : "Layer of surrounding neighbor to be affected" : 1
 ]
 
 // info_room_target

--- a/tools/sdhlt.fgd
+++ b/tools/sdhlt.fgd
@@ -77,25 +77,27 @@
 // info_overview_point
 // It makes all entities visible from this place. This is useful for overview mode (dev_overview 1).
 // If "Reversed" is selected, this place will become visible from the entire map. This is useful for large skybox model.
-@PointClass color(255 0 0) = info_overview_point : "Disable VIS here for overview"
+@PointClass color(255 0 0) = info_overview_point : "Disable VIS here by creating portals to every other leaf. Lag/wallhack warning. If reversed, every other leaf has a portal to this one."
 [
-	reverse(choices) : "Reversed" : "" =
+	reverse(choices) : "Reversed (3D skybox)" : "" =
 	[
 		"": "No"
 		1: "Yes"
 	]
 ]
 
-// info_room
-// It makes all entities inside info_room_target visible inside the room where this entity is.
-@PointClass color(255 255 255) = info_room : "Disable VIS in info_room_target for this room"
+// info_portal
+// TODO: vector for target so it can do a lot. Though doing the entity won't be as simple.
+// That means we need to parse string and what not. 
+// For the time being, ONE target is good enough.
+@PointClass color(255 200 200) = info_portal : "Create a portal to the selected info_leaf, from the leaf the info_portal is inside. Forces target leaf to be visible from the current one."
 [
-	target(target_source) : "Name of info_room_target"
-	neighbor(interger) : "Layer of surrounding neighbor to be affected" : 1
+	target(target_source) : "Name of info_leaf"
+	neighbor(integer) : "TODO: Layers of neighboring leaves to be affected" : 1
 ]
 
-// info_room_target
-@PointClass color(255 255 255) = info_room_target : "Disable VIS in this room for info_room"
+// info_leaf
+@PointClass color(200 200 255) = info_leaf : "Works with info_portal. Used to select a leaf the info_leaf is inside."
 [
 	targetname(target_destination) : "Name"
 ]


### PR DESCRIPTION
Two new entities, `info_room` and `info_room_target`. They both are meant to be used with one another.

They work like `info_overview_point` "reverse mode" where "everything outside the room can see everything inside the room". But this is a lot more customizable where we can select where "outside" is.

`info_room` indicates where you want to see entities inside `info_room_target`.

Here is an example map.
[Archive.zip](https://github.com/seedee/SDHLT/files/14844535/Archive.zip)

I think there are a lot of use cases to this. Maybe a 3D skybox, multiple skyboxes, or very high resolution skybox (they all need to be a studio model). Those could be enclosed inside a visbreak box. `info_room_target` will be inside that box. Now we just need to scatter `info_room` appropriately so the skybox model would render. I think some other people might have better ideas than I do.
