### PR TITLE
Removing QuArK texture params format stuffs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ Temporary Items
 /build*/
 .vs/SDHLT/v17/.wsuo
 .vs/SDHLT/v17/DocumentLayout.json
+.vscode/settings.json

--- a/src/sdhlt/common/scriplib.cpp
+++ b/src/sdhlt/common/scriplib.cpp
@@ -5,7 +5,6 @@
 #include "scriplib.h"
 
 char            g_token[MAXTOKEN];
-char            g_TXcommand;
 
 typedef struct
 {
@@ -185,9 +184,6 @@ skipspace:
         //ets+++
         if (*s_script->script_p == '/')
             s_script->script_p++;
-        if (s_script->script_p[1] == 'T' && s_script->script_p[2] == 'X')
-            g_TXcommand = s_script->script_p[3];             // AR: "//TX#"-style comment
-
         //ets---
         while (*s_script->script_p++ != '\n')
         {

--- a/src/sdhlt/common/scriplib.h
+++ b/src/sdhlt/common/scriplib.h
@@ -10,7 +10,6 @@
 #define	MAXTOKEN 4096
 
 extern char     g_token[MAXTOKEN];
-extern char     g_TXcommand;                               // global for Quark maps texture alignment hack
 
 extern void     LoadScriptFile(const char* const filename);
 extern void     ParseFromMemory(char* buffer, int size);

--- a/src/sdhlt/sdHLCSG/csg.h
+++ b/src/sdhlt/sdHLCSG/csg.h
@@ -93,15 +93,9 @@ typedef struct
     vec_t           scale[2];
 } valve_vects;
 
-typedef struct
-{
-    float           vects[2][4];
-} quark_vects;
-
 typedef union
 {
     valve_vects     valve;
-    quark_vects     quark;
 }
 vects_union;
 
@@ -109,7 +103,6 @@ extern int      g_nMapFileVersion;                         // map file version *
 
 typedef struct
 {
-    char            txcommand;
     vects_union     vects;
     char            name[32];
 } brush_texture_t;


### PR DESCRIPTION
Removing QuArK-special '//TX1'  '//TX2' indicator stuffs. 
idk exactly what it is, but who uses QuArK for mapping lol? In addition, QuArK allows working with Valve220 map format so...
 Comment from QuArK source/trunk/prog/QkMap.pas : ```"//TX#" means that the three points already define the texture params themselves``` 
 
Also TODO task: it would be good to remove map version < 220 stuffs , since 220 is the standard nowaday.