### PR TITLE
Make sky texture checks case-insensitive

### DIFF
--- a/src/sdhlt/common/bspfile.cpp
+++ b/src/sdhlt/common/bspfile.cpp
@@ -861,7 +861,7 @@ int CountBlocks ()
 	{
 		dface_t *f = &g_dfaces[k];
 		const char *texname =  GetTextureByNumber (ParseTexinfoForFace (f));
-		if (!strncmp (texname, "sky", 3) //sky, no lightmap allocation.
+		if (!strncasecmp (texname, "sky", 3) //sky, no lightmap allocation.
 			|| !strncmp (texname, "!", 1) || !strncasecmp (texname, "water", 5) || !strncasecmp (texname, "laser", 5) //water, no lightmap allocation.
 			|| (g_texinfo[ParseTexinfoForFace (f)].flags & TEX_SPECIAL) //aaatrigger, I don't know.
 			)

--- a/src/sdhlt/sdHLRAD/lightmap.cpp
+++ b/src/sdhlt/sdHLRAD/lightmap.cpp
@@ -4512,7 +4512,7 @@ void MLH_GetSamples_r (mdllight_t *ml, int nodenum, const float *start, const fl
 			dface_t *f = &g_dfaces[node->firstface + i];
 			texinfo_t *tex = &g_texinfo[f->texinfo];
 			const char *texname = GetTextureByNumber (f->texinfo);
-			if (!strncmp (texname, "sky", 3))
+			if (!strncasecmp (texname, "sky", 3))
 			{
 				continue;
 			}

--- a/src/sdhlt/sdHLRAD/loadtextures.cpp
+++ b/src/sdhlt/sdHLRAD/loadtextures.cpp
@@ -1059,7 +1059,7 @@ void EmbedLightmapInTextures ()
 		{
 			continue;
 		}
-		if (!strncmp (texname, "sky", 3)
+		if (!strncasecmp (texname, "sky", 3)
 			|| originaltexinfo->flags & TEX_SPECIAL) // skip special surfaces
 		{
 			continue;


### PR DESCRIPTION
Having a lump texture name set to any other name than "sky" (lowercase) would fail to properly treat the texture as the special sky texture.

The only other remaining instances of case-sentitive name checking is done to check for the sdhlt.wad file specifically (and only for logging purposes) so it was kept as-is.