### PR TITLE
Add `-nohull3`

### DIFF
--- a/src/sdhlt/sdHLBSP/bsp5.h
+++ b/src/sdhlt/sdHLBSP/bsp5.h
@@ -308,6 +308,7 @@ extern char		g_extentfilename[_MAX_PATH];
 extern bool     g_bUseNullTex;
 
 extern bool		g_nohull2;
+extern bool		g_nohull3;
 
 extern face_t*  NewFaceFromFace(const face_t* const in);
 extern void     SplitFace(face_t* in, const dplane_t* const split, face_t** front, face_t** back);

--- a/src/sdhlt/sdHLBSP/outside.cpp
+++ b/src/sdhlt/sdHLBSP/outside.cpp
@@ -446,8 +446,15 @@ node_t*         FillOutside(node_t* node, const bool leakfile, const unsigned hu
         Log("skipped\n");
         return node;
     }
+    
 	if (hullnum == 2 && g_nohull2)
+    {
 		return node;
+    }
+    else if (hullnum == 3 && g_nohull3)
+    {
+		return node;
+    }
 
     //
     // place markers for all entities so

--- a/src/sdhlt/sdHLBSP/qbsp.cpp
+++ b/src/sdhlt/sdHLBSP/qbsp.cpp
@@ -74,6 +74,7 @@ bool            g_bUseNullTex = DEFAULT_NULLTEX; // "-nonulltex"
 
 
 bool g_nohull2 = false;
+bool g_nohull3 = false;
 
 bool g_viewportal = false;
 
@@ -971,7 +972,13 @@ static surfchain_t* ReadSurfs(FILE* file)
     while (1)
     {
 		if (file == polyfiles[2] && g_nohull2)
+		{
 			break;
+		}
+		else if (file == polyfiles[3] && g_nohull3)
+		{
+			break;
+		}
         line++;
         r = fscanf(file, "%i %i %i %i %i\n", &detaillevel, &planenum, &g_texinfo, &contents, &numpoints);
         if (r == 0 || r == -1)
@@ -1062,7 +1069,14 @@ static brush_t *ReadBrushes (FILE *file)
 	while (1)
 	{
 		if (file == brushfiles[2] && g_nohull2)
+        {
 			break;
+        }
+		else if (file == brushfiles[3] && g_nohull3)
+        {
+			break;
+        }
+
 		int r;
 		int brushinfo;
 		r = fscanf (file, "%i\n", &brushinfo);
@@ -1407,6 +1421,7 @@ static void     Usage()
 
 
 	Log("    -nohull2       : Don't generate hull 2 (the clipping hull for large monsters and pushables)\n");
+	Log("    -nohull3       : Don't generate hull 2 (the clipping hull for crouching and small pushables)\n");
 
 	Log("    -viewportal    : Show portal boundaries in 'mapname_portal.pts' file\n");
 
@@ -1478,6 +1493,7 @@ static void     Settings()
     Log("max node size       [ %7d ] [ %7d ] (Min %d) (Max %d)\n",
         g_maxnode_size, DEFAULT_MAXNODE_SIZE, MIN_MAXNODE_SIZE, MAX_MAXNODE_SIZE);
 	Log("remove hull 2       [ %7s ] [ %7s ]\n", g_nohull2? "on": "off", "off");
+	Log("remove hull 3       [ %7s ] [ %7s ]\n", g_nohull3? "on": "off", "off");
     Log("\n\n");
 }
 
@@ -1765,6 +1781,11 @@ int             main(const int argc, char** argv)
 		else if (!strcasecmp (argv[i], "-nohull2"))
 		{
 			g_nohull2 = true;
+		}
+        
+        else if (!strcasecmp (argv[i], "-nohull3"))
+		{
+			g_nohull3 = true;
 		}
 
 		else if (!strcasecmp(argv[i], "-noopt"))

--- a/src/sdhlt/sdHLBSP/qbsp.cpp
+++ b/src/sdhlt/sdHLBSP/qbsp.cpp
@@ -1421,7 +1421,7 @@ static void     Usage()
 
 
 	Log("    -nohull2       : Don't generate hull 2 (the clipping hull for large monsters and pushables)\n");
-	Log("    -nohull3       : Don't generate hull 2 (the clipping hull for crouching and small pushables)\n");
+	Log("    -nohull3       : Don't generate hull 3 (the clipping hull for crouching and small pushables)\n");
 
 	Log("    -viewportal    : Show portal boundaries in 'mapname_portal.pts' file\n");
 


### PR DESCRIPTION
Like `-nohull2`, but affects hull 3 instead. This can be useful for games without crouching, such as Deathmatch Classic, when making a map without small pushables.

This is a draft PR because I haven't figured out how to compile this repo yet. If I understand the nohull2 code correctly though, this should work.