### PR TITLE
TrenchBroom portal file (.prt) support

### DIFF
--- a/src/sdhlt/sdHLVIS/vis.cpp
+++ b/src/sdhlt/sdHLVIS/vis.cpp
@@ -1326,7 +1326,7 @@ int        VisLeafnumForPoint(const vec3_t point)
 //  FixPrt
 //      Imports portal file to vector, erases vis cache lines, overwrites portal file
 // =====================================================================================
-void FixPrt(const char* portalfile)
+void FixPrt(const char* portalfile, bool tb_fix)
 {
     Log("\nReading portal file '%s'\n", portalfile);
 
@@ -1338,7 +1338,7 @@ void FixPrt(const char* portalfile)
 
     if (!inputFileStream) //If import fails
     {
-        Log("Failed reading portal file '%s', skipping optimization for J.A.C.K. map editor\n", portalfile);
+        Log("Failed reading portal file '%s', skipping optimization for J.A.C.K./TrenchBroom map editor\n", portalfile);
         return;
     }
 
@@ -1380,12 +1380,18 @@ void FixPrt(const char* portalfile)
     }
     if (skipFix)
     {
-        Log("Skipping optimization for J.A.C.K. map editor\n");
+        Log("Skipping optimization for J.A.C.K./TrenchBroom map editor\n");
         return;
     }
     prtVector.erase( //Deletes from string 3 until string before portal coordinates
         prtVector.begin() + 2,
         itPortalCoords);
+
+    if (tb_fix) // TB prt file format
+    {
+        prtVector[0] = PORTALFILE; // header
+        prtVector.insert(prtVector.begin() + 1, "0");
+    }
 
     optimizedPortalFileLines = prtVector.size(); //Count lines after optimization
 
@@ -1408,12 +1414,18 @@ void FixPrt(const char* portalfile)
             outputFileStream << prtVector[i] << "\n"; //Print each string as a new line
         }
         outputFileStream.close();
-
-        Log("Optimization for J.A.C.K. map editor successful, writing portal file '%s'\n", portalfile);
+        if (tb_fix)
+        {
+            Log("Optimization for TrenchBroom map editor successful, writing portal file '%s'\n", portalfile);
+        }
+        else
+        {
+            Log("Optimization for J.A.C.K. map editor successful, writing portal file '%s'\n", portalfile);
+        }
     }
     else //If open fails
     {
-        Log("Failed writing portal file '%s', skipping optimization for J.A.C.K. map editor\n", portalfile);
+        Log("Failed writing portal file '%s', skipping optimization for J.A.C.K./TrenchBroom map editor\n", portalfile);
         return;
     }
 
@@ -1429,6 +1441,7 @@ int             main(const int argc, char** argv)
     int             i;
     double          start, end;
     const char*     mapname_from_arg = NULL;
+    bool            tb_prt = false;
 
 #ifdef ZHLT_NETVIS
     g_Program = "netvis";
@@ -1659,6 +1672,10 @@ int             main(const int argc, char** argv)
 				Usage();
 			}
 		}
+        else if (!strcasecmp (argv[i], "-tbprt"))
+        {
+            tb_prt = true;
+        }
 
         else if (argv[i][0] == '-')
         {
@@ -1983,7 +2000,7 @@ int             main(const int argc, char** argv)
 
     if (!g_nofixprt) //seedee
     {
-        FixPrt(portalfile);
+        FixPrt(portalfile, tb_prt);
     }
 
     if (g_chart)

--- a/src/sdhlt/sdHLVIS/vis.h
+++ b/src/sdhlt/sdHLVIS/vis.h
@@ -44,7 +44,7 @@
 #define RVIS_LEVEL_1
 #define RVIS_LEVEL_2
 
-#define PORTALFILE      "PRT1" // WTF?
+#define PORTALFILE      "PRT1" // Quake portal file header, required for TrenchBroom prt file
 
 #define	MAX_POINTS_ON_FIXED_WINDING	32
 


### PR DESCRIPTION
A new HLVIS compile parameter `-tbprt` for fix prt files for TrenchBroom.
The diffs from JACK .prt file is that TB .prt uses a header `PRT1` and second line is 0.

Fixed .prt for JACK:
```
7
6
4 0 6 (208.000000 544.000000 192.000000) (208.000000 544.000000 0.000000) (208.000000 176.000000 0.000000) (208.000000 176.000000 192.000000) 
4 0 1 (688.000000 176.000000 192.000000) (416.000000 176.000000 192.000000) (416.000000 176.000000 0.000000) (688.000000 176.000000 0.000000) 
4 1 2 (512.000000 96.000000 0.000000) (608.000000 96.000000 0.000000) (608.000000 96.000000 128.000000) (512.000000 96.000000 128.000000) 
4 2 3 (512.000000 32.000000 0.000000) (608.000000 32.000000 0.000000) (608.000000 32.000000 128.000000) (512.000000 32.000000 128.000000) 
4 3 4 (416.000000 -304.000000 192.000000) (416.000000 -112.000000 192.000000) (416.000000 -112.000000 0.000000) (416.000000 -304.000000 0.000000) 
4 4 6 (208.000000 -112.000000 0.000000) (208.000000 -304.000000 0.000000) (208.000000 -304.000000 192.000000) (208.000000 -112.000000 192.000000)  
```

Fixed .prt for TrenchBoom:
```
PRT1
0
6
4 0 6 (208.000000 544.000000 192.000000) (208.000000 544.000000 0.000000) (208.000000 176.000000 0.000000) (208.000000 176.000000 192.000000) 
4 0 1 (688.000000 176.000000 192.000000) (416.000000 176.000000 192.000000) (416.000000 176.000000 0.000000) (688.000000 176.000000 0.000000) 
4 1 2 (512.000000 96.000000 0.000000) (608.000000 96.000000 0.000000) (608.000000 96.000000 128.000000) (512.000000 96.000000 128.000000) 
4 2 3 (512.000000 32.000000 0.000000) (608.000000 32.000000 0.000000) (608.000000 32.000000 128.000000) (512.000000 32.000000 128.000000) 
4 3 4 (416.000000 -304.000000 192.000000) (416.000000 -112.000000 192.000000) (416.000000 -112.000000 0.000000) (416.000000 -304.000000 0.000000) 
4 4 6 (208.000000 -112.000000 0.000000) (208.000000 -304.000000 0.000000) (208.000000 -304.000000 192.000000) (208.000000 -112.000000 192.000000) 
```


![image](https://github.com/user-attachments/assets/e2e92313-289b-49ba-b53a-6f77dd4a8686)
![image](https://github.com/user-attachments/assets/433fd72b-8137-4eed-8312-549c1d9717f6)
